### PR TITLE
[Sprint 22] - [Hotfix] Fix Include File

### DIFF
--- a/include/ninshiki_cpp/node/ninshiki_cpp_node.hpp
+++ b/include/ninshiki_cpp/node/ninshiki_cpp_node.hpp
@@ -34,6 +34,7 @@
 #include "ninshiki_cpp/detector/dnn_detector.hpp"
 #include "ninshiki_cpp/detector/lbp_detector.hpp"
 #include "ninshiki_interfaces/msg/detected_objects.hpp"
+#include "shisen_interfaces/msg/image.hpp"
 #include "shisen_cpp/shisen_cpp.hpp"
 
 namespace ninshiki_cpp::node


### PR DESCRIPTION
## Jira Link: 

## Description

Found an error when building the package because of file include

<img width="1203" alt="image" src="https://github.com/ichiro-its/ninshiki_cpp/assets/67451619/82ebfc93-fef5-4493-8f67-3dcf74ca3721">


## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.