### PR TITLE
[PI Sprint 24/25] [Hotfix] - Fix Get Binary Mat

### DIFF
--- a/include/ninshiki_cpp/utils/rect.hpp
+++ b/include/ninshiki_cpp/utils/rect.hpp
@@ -33,7 +33,7 @@ private:
 
 public:
   Rect(const cv::Rect & rect);
-  const cv::Mat & get_binary_mat(const cv::Size & mat_size, int line_size = cv::FILLED) const;
+  const cv::Mat get_binary_mat(const cv::Size & mat_size, int line_size = cv::FILLED) const;
 
   const cv::Point2f & get_center() const;
 };

--- a/src/ninshiki_cpp/utils/rect.cpp
+++ b/src/ninshiki_cpp/utils/rect.cpp
@@ -25,7 +25,7 @@ namespace ninshiki_cpp::utils
 
 Rect::Rect(const cv::Rect & rect) : rect(rect) {}
 
-const cv::Mat & Rect::get_binary_mat(const cv::Size & mat_size, int line_size) const
+const cv::Mat Rect::get_binary_mat(const cv::Size & mat_size, int line_size) const
 {
   cv::Mat binary_mat(mat_size, CV_8UC1, cv::Scalar(0));
 


### PR DESCRIPTION
## Jira Link: 

## Description

Return copy of get binary mat instead of reference.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.