### PR TITLE
[PI Sprint 24/25] [Enhancement] - Inverted Hue Classification

### DIFF
--- a/include/ninshiki_cpp/detector/color_detector.hpp
+++ b/include/ninshiki_cpp/detector/color_detector.hpp
@@ -79,6 +79,7 @@ public:
 private:
   int classifier_type;
 
+  bool invert_hue;
   int min_hue;
   int max_hue;
   int min_saturation;

--- a/include/ninshiki_cpp/utils/color.hpp
+++ b/include/ninshiki_cpp/utils/color.hpp
@@ -30,10 +30,12 @@ class Color
 {
 public:
   Color(
-    const std::string & name, int min_hue, int max_hue, int min_saturation,
-    int max_saturation, int min_value, int max_value);
+    const std::string & name, bool invert_hue, int min_hue,
+    int max_hue, int min_saturation, int max_saturation,
+    int min_value, int max_value);
 
   std::string name;
+  bool invert_hue;
   int min_hue;
   int max_hue;
   int min_saturation;

--- a/src/ninshiki_cpp/config/node/config_node.cpp
+++ b/src/ninshiki_cpp/config/node/config_node.cpp
@@ -72,6 +72,7 @@ ConfigNode::ConfigNode(rclcpp::Node::SharedPtr node, const std::string & path,
       try {
         utils::Color color(
           request->name,
+          request->invert_hue,
           request->min_hue, request->max_hue,
           request->min_saturation, request->max_saturation,
           request->min_value, request->max_value

--- a/src/ninshiki_cpp/utils/color.cpp
+++ b/src/ninshiki_cpp/utils/color.cpp
@@ -26,10 +26,10 @@ namespace ninshiki_cpp::utils
 {
 
 Color::Color(
-  const std::string & name, int min_hue, int max_hue,
-  int min_saturation, int max_saturation, int min_value,
-  int max_value)
-: name(name), min_hue(min_hue), max_hue(max_hue),
+  const std::string & name, bool invert_hue, int min_hue,
+  int max_hue, int min_saturation, int max_saturation,
+  int min_value, int max_value)
+: name(name), invert_hue(invert_hue), min_hue(min_hue), max_hue(max_hue),
   min_saturation(min_saturation), max_saturation(max_saturation),
   min_value(min_value), max_value(max_value)
 {


### PR DESCRIPTION
## Jira Link: 

## Description

Handle inverted hue for color classification, especially for red (e.g., range 355–7 becomes 0–7 and 355–360). 
Hue space should be treated as circular rather than linear. 
Changes in ichiro-app can be seen in the `feature/hurocup-page` branch.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.